### PR TITLE
Fix installations using Carton or Carmel

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,13 +2,6 @@ use strict;
 use warnings;
 use ExtUtils::MakeMaker;
 
-my $choice = 'Builder';  # API2 or Builder default prerequisite?
-my $debug = 0;  # 1 to just dump contents
-my %versions = (  # minimum version for either
-    'API2'    => 2.038,
-    'Builder' => 3.021,
-);
-
 my %WriteMakefileArgs = (
     NAME                => 'PDF::TextBlock',
     AUTHOR              => 'Jay Hannah <jay@jays.net>',
@@ -36,38 +29,3 @@ my %WriteMakefileArgs = (
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'PDF-TextBlock-*' },
 );
-
-# if neither PDF::API2 nor PDF::Builder is installed, prereq one of them
-my $rc;
-$rc = eval {
-    require PDF::API2;
-    1;
-};
-if (!defined $rc) { $rc = 0; }
-if ($rc) {
-    # PDF::API2 installed but not up to date?
-    if ($PDF::API2::VERSION < $versions{'API2'}) { $rc = 0; }
-}
-if (!$rc) {
-    # no PDF::API2. try PDF::Builder.
-    $rc = eval {
-        require PDF::Builder;
-        1;
-    };
-    if (!defined $rc) { $rc = 0; }
-    if ($rc) {
-        # PDF::Builder installed but not up to date?
-        if ($PDF::Builder::VERSION < $versions{'Builder'}) { $rc = 0; }
-    }
-}
-# suitable level of PDF::* not already installed?
-if (!$rc) {
-    $WriteMakefileArgs{'PREREQ_PM'}{"PDF::$choice"} = $versions{$choice};
-}
-
-if ($debug) {
-    use Data::Dumper;  # two lines for checking prereq work
-    print Dumper(\%WriteMakefileArgs);
-} else {
-    WriteMakefile(%WriteMakefileArgs);
-}


### PR DESCRIPTION
Hello. Looks like it's impossible to install this module using [Carton](https://metacpan.org/pod/Carton).
We're going to start using Carton in our workflows, but we faced the following problem:

```
! Couldn't find module or a distribution PDF::Builder (3.021)
Successfully installed Class-Accessor-0.51
! Installing the dependencies failed: Module 'PDF::Builder' is not installed
! Bailing out the installation for PDF-TextBlock-0.13.
```

We're using `PDF::API2` inside our application and when PDF::TextBlock is going to be installed earlier PDF::API2 it tries to install PDF::Builder because of behavior defined in Makefile.PL. I think it's better for everyone to remove this code and if someone will forget to install PDF::API2 or PDF::Builder i'm sure he will know about this very soon.

As I can see from code inside PDF::TextBlock module it will not cause any compilation time errors related to PDF::API2 or PDF::Builder modules because there is no explicit `use` or `require` statements inside packages. 
